### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # MCP Steam Server
 
+[![smithery badge](https://smithery.ai/badge/@dsp/mcp-server-steam)](https://smithery.ai/server/@dsp/mcp-server-steam)
+
 A Model Context Protocol (MCP) server that provides Steam gaming context to AI assistants. This service integrates with the Steam API to fetch user gaming information and exposes it through the MCP protocol, allowing AI assistants to access and understand users' gaming activities and preferences.
 
 ## Installation
+
+### Installing via Smithery
+
+To install Steam Gaming Context Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@dsp/mcp-server-steam):
+
+```bash
+npx -y @smithery/cli install @dsp/mcp-server-steam --client claude
+```
 
 ### Using Docker (Recommended)
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - steamApiKey
+    properties:
+      steamApiKey:
+        type: string
+        description: The API key for accessing the Steam API.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'java', args: ['-jar', 'app.jar'], env: { STEAM_API_KEY: config.steamApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@dsp/mcp-server-steam?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂